### PR TITLE
Added support to load an external system properties file

### DIFF
--- a/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
+++ b/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
@@ -69,4 +69,6 @@ public interface PropertyNames {
 
     String USERNAME = "jboss-as.username";
 
+    String PROPERTIES_FILE = "jboss-as.propertiesFile";
+
 }

--- a/src/main/java/org/jboss/as/plugin/server/Run.java
+++ b/src/main/java/org/jboss/as/plugin/server/Run.java
@@ -126,6 +126,12 @@ public class Run extends Deploy {
     private String serverConfig;
 
     /**
+     * The path to the system properties file to load.
+     */
+    @Parameter(alias = "properties-file", property = PropertyNames.PROPERTIES_FILE)
+    private String propertiesFile;
+
+    /**
      * The timeout value to use when starting the server.
      */
     @Parameter(alias = "startup-timeout", defaultValue = Defaults.TIMEOUT, property = PropertyNames.STARTUP_TIMEOUT)
@@ -154,7 +160,7 @@ public class Run extends Deploy {
         } else {
             javaHome = this.javaHome;
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, bundlesPath, jvmArgs, serverConfig, startupTimeout);
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
         if (!serverInfo.getModulesDir().isDirectory()) {
             throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", modulesPath));
         }

--- a/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
+++ b/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
@@ -40,9 +40,10 @@ class ServerInfo {
     private final String[] jvmArgs;
     private final String javaHome;
     private final String serverConfig;
+    private final String propertiesFile;
     private final long startupTimeout;
 
-    private ServerInfo(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final long startupTimeout) {
+    private ServerInfo(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
         this.connectionInfo = connectionInfo;
         this.javaHome = javaHome;
         this.jbossHome = jbossHome;
@@ -50,6 +51,7 @@ class ServerInfo {
         this.bundlesDir = (bundlesDir == null ? Files.createFile(jbossHome, "bundles") : new File(bundlesDir));
         this.jvmArgs = jvmArgs;
         this.serverConfig = serverConfig;
+        this.propertiesFile = propertiesFile;
         this.startupTimeout = startupTimeout;
     }
 
@@ -67,8 +69,8 @@ class ServerInfo {
      *
      * @return the server configuration information
      */
-    public static ServerInfo of(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final long startupTimeout) {
-        return new ServerInfo(connectionInfo, javaHome, jbossHome, modulesDir, bundlesDir, jvmArgs, serverConfig, startupTimeout);
+    public static ServerInfo of(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
+        return new ServerInfo(connectionInfo, javaHome, jbossHome, modulesDir, bundlesDir, jvmArgs, serverConfig, propertiesFile, startupTimeout);
     }
 
     /**
@@ -132,6 +134,15 @@ class ServerInfo {
      */
     public String getServerConfig() {
         return serverConfig;
+    }
+
+    /**
+     * The path to the system properties file to load.
+     *
+     * @return the path to the properties file or {@code null} if no properties should be loaded.
+     */
+    public String getPropertiesFile() {
+        return propertiesFile;
     }
 
     /**

--- a/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
@@ -137,6 +137,10 @@ final class StandaloneServer extends Server {
             cmd.add("-server-config");
             cmd.add(serverInfo.getServerConfig());
         }
+        if (serverInfo.getPropertiesFile() != null) {
+            cmd.add("-P");
+            cmd.add(serverInfo.getPropertiesFile());
+        }
         return cmd;
     }
 

--- a/src/main/java/org/jboss/as/plugin/server/Start.java
+++ b/src/main/java/org/jboss/as/plugin/server/Start.java
@@ -124,6 +124,12 @@ public class Start extends AbstractServerConnection {
     private String serverConfig;
 
     /**
+     * The path to the system properties file to load.
+     */
+    @Parameter(alias = "properties-file", property = PropertyNames.PROPERTIES_FILE)
+    private String propertiesFile;
+
+    /**
      * The timeout value to use when starting the server.
      */
     @Parameter(alias = "startup-timeout", defaultValue = Defaults.TIMEOUT, property = PropertyNames.STARTUP_TIMEOUT)
@@ -145,7 +151,7 @@ public class Start extends AbstractServerConnection {
         } else {
             javaHome = this.javaHome;
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, bundlesPath, jvmArgs, serverConfig, startupTimeout);
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
         if (!serverInfo.getModulesDir().isDirectory()) {
             throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", modulesPath));
         }


### PR DESCRIPTION
JBoss has support for loading an external system properties file during
startup with the -P flag, added option for configuring this in the
plugin.
