### PR TITLE
Add 'deployEnabled' option to allow a deployed war to remain deactivated

### DIFF
--- a/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
+++ b/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
@@ -35,6 +35,8 @@ public interface PropertyNames {
 
     String DEPLOY_FORCE = "deploy.force";
 
+    String DEPLOY_ENABLED = "deploy.enabled";
+
     String DEPLOYMENT_FILENAME = "jboss-as.deployment.filename";
 
     String DEPLOYMENT_TARGET_DIR = "jboss-as.deployment.targetDir";

--- a/src/main/java/org/jboss/as/plugin/deployment/Deploy.java
+++ b/src/main/java/org/jboss/as/plugin/deployment/Deploy.java
@@ -55,6 +55,20 @@ public class Deploy extends AbstractAppDeployment {
     @Parameter(defaultValue = "true", property = PropertyNames.DEPLOY_FORCE)
     private boolean force;
 
+    /**
+     * Specifies whether the deployed application should be automatically enabled or not.
+     * <p>
+     * If enabled, the deploy goal will automatically run the application in the target container. If disabled, the
+     * content will be uploaded but not deployed.
+     * <p>
+     * Note that if an application of the same name is already running and the <tt>force</tt> parameter is true, the
+     * application will be enabled automatically, even if this parameter is false (disabled). That is, an enabled
+     * application will not be disabled by re-deployment. The converse is true, i.e. a disabled application may be
+     * enabled by a forced deployment of the same content where this parameter is true.
+     */
+    @Parameter(defaultValue = "true", property = PropertyNames.DEPLOY_ENABLED)
+    private boolean deployEnabled = true;
+
     @Override
     public String goal() {
         return "deploy";
@@ -62,7 +76,11 @@ public class Deploy extends AbstractAppDeployment {
 
     @Override
     public Type getType() {
-        return (force ? Type.FORCE_DEPLOY : Type.DEPLOY);
+        if (deployEnabled) {
+            return (force ? Type.FORCE_DEPLOY : Type.DEPLOY);
+        } else {
+            return (force ? Type.FORCE_ADD : Type.ADD);
+        }
     }
 
 }

--- a/src/main/java/org/jboss/as/plugin/deployment/Deployment.java
+++ b/src/main/java/org/jboss/as/plugin/deployment/Deployment.java
@@ -31,6 +31,7 @@ import org.jboss.as.plugin.common.DeploymentFailureException;
 public interface Deployment {
 
     public enum Type {
+        ADD, FORCE_ADD,
         DEPLOY,
         FORCE_DEPLOY,
         UNDEPLOY,

--- a/src/main/java/org/jboss/as/plugin/deployment/domain/DomainDeployment.java
+++ b/src/main/java/org/jboss/as/plugin/deployment/domain/DomainDeployment.java
@@ -105,13 +105,25 @@ public class DomainDeployment implements Deployment {
         DeploymentActionsCompleteBuilder completeBuilder = null;
         List<String> existingDeployments = DeploymentInspector.getDeployments(client, name, matchPattern);
         switch (type) {
+            case ADD: {
+                completeBuilder = builder.add(name, content);
+                break;
+            }
+            case FORCE_ADD: {
+                if (existingDeployments.contains(name)) {
+                    completeBuilder = builder.replace(name, content);
+                } else {
+                    completeBuilder = builder.add(name, content);
+                }
+                break;
+            }
             case DEPLOY: {
                 completeBuilder = builder.add(name, content).andDeploy();
                 break;
             }
             case FORCE_DEPLOY: {
                 if (existingDeployments.contains(name)) {
-                    completeBuilder = builder.replace(name, content);
+                    completeBuilder = builder.replace(name, content).deploy(name);
                 } else {
                     completeBuilder = builder.add(name, content).andDeploy();
                 }

--- a/src/main/java/org/jboss/as/plugin/deployment/standalone/StandaloneDeployment.java
+++ b/src/main/java/org/jboss/as/plugin/deployment/standalone/StandaloneDeployment.java
@@ -97,6 +97,18 @@ public class StandaloneDeployment implements Deployment {
         List<String> existingDeployments = DeploymentInspector.getDeployments(client, name, matchPattern);
 
         switch (type) {
+            case ADD: {
+                planBuilder = builder.add(name, content);
+                break;
+            }
+            case FORCE_ADD: {
+                if (existingDeployments.contains(name)) {
+                    planBuilder = builder.replace(name, content);
+                } else {
+                    planBuilder = builder.add(name, content);
+                }
+                break;
+            }
             case DEPLOY: {
                 planBuilder = builder.add(name, content).andDeploy();
                 break;
@@ -112,7 +124,7 @@ public class StandaloneDeployment implements Deployment {
             }
             case FORCE_DEPLOY: {
                 if (existingDeployments.contains(name)) {
-                    planBuilder = builder.replace(name, content).redeploy(name);
+                    planBuilder = builder.replace(name, content).deploy(name);
                 } else {
                     planBuilder = builder.add(name, content).andDeploy();
                 }

--- a/src/site/apt/examples/deployment-example.apt.vm
+++ b/src/site/apt/examples/deployment-example.apt.vm
@@ -11,7 +11,7 @@ Deploy/Undeploy Examples
 * Deploying your application
 
   The plugin goals {{{../deploy-mojo.html}deploy}}, {{{../undeploy-mojo.html}undeploy}},
-  and {{{../redeploy-mojo.html}redeploy}} can be used to deploy, redeploy and undeploy applications
+  and {{{../redeploy-mojo.html}redeploy}} can be used to deploy, undeploy and redeploy applications
   to a JBoss Application Server. The first step is to add the appropriate configuration
   to your plugin configuration in the POM.
 
@@ -195,6 +195,44 @@ Deploy/Undeploy Examples
                         </server-groups>
                     </domain>
                 </configuration>
+            </plugin>
+            ...
+        </plugins>
+        ...
+    </build>
+...
+</project>
+----------
+
+
+* Deploying your application without launching it.
+
+  JBoss AS allows content to be disabled or enabled via the management interface. The default deployment goals above
+  will automatically enable the content, which may not be desirable. To avoid this, change the <<<deployEnabled>>>
+  parameter.
+
+----------
+<project>
+    ...
+    <build>
+        ...
+        <plugins>
+            ...
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <deployEnabled>false</deployEnabled>
+                        <configuration>
+                    </execution>
+                </executions>
             </plugin>
             ...
         </plugins>

--- a/src/test/java/org/jboss/as/plugin/deployment/DeployTest.java
+++ b/src/test/java/org/jboss/as/plugin/deployment/DeployTest.java
@@ -58,6 +58,35 @@ public class DeployTest extends AbstractItTestCase {
     }
 
     @Test
+    public void testAdd() throws Exception {
+
+        // Make sure the archive is not deployed
+        if (isDeployed(DEPLOYMENT_NAME)) {
+            undeploy(DEPLOYMENT_NAME);
+        }
+
+        final MavenProject mavenProject = new MavenProject();
+        mavenProject.setPackaging("war");
+
+        final File pom = getPom("deploy-disabled-webarchive-pom.xml");
+
+        final AbstractDeployment deployMojo = lookupMojoAndVerify("deploy", pom);
+
+        deployMojo.project = mavenProject;
+        deployMojo.execute();
+
+        // Verify deployed
+        assertTrue("Deployment " + DEPLOYMENT_NAME + " was not deployed", isDeployed(DEPLOYMENT_NAME));
+
+        // /deployment=test.war :read-attribute(name=status)
+        final ModelNode address = ServerOperations.createAddress("deployment", DEPLOYMENT_NAME);
+        final ModelNode op = ServerOperations.createReadAttributeOperation(address, "status");
+        final ModelNode result = executeOperation(managementClient.getControllerClient(), op);
+
+        assertEquals("STOPPED", ServerOperations.readResultAsString(result));
+    }
+
+    @Test
     public void testDeployWithCommands() throws Exception {
 
         // Make sure the archive is not deployed

--- a/src/test/resources/unit/common/add-webarchive-pom.xml
+++ b/src/test/resources/unit/common/add-webarchive-pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>testing</groupId>
+	<artifactId>testing</artifactId>
+	<packaging>war</packaging>
+	<version>0.1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jboss.as.plugins</groupId>
+				<artifactId>jboss-as-maven-plugin</artifactId>
+				<executions>
+						<execution>
+							<goals>
+								<goal>add</goal>
+							</goals>
+						</execution>
+					</executions>
+				<configuration>
+					<id>testid</id>
+					<port>10099</port>
+					<targetDir>src/test/resources/unit/common/</targetDir>
+					<filename>test.war</filename>
+					<checkPackaging>false</checkPackaging>
+				</configuration>
+
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/test/resources/unit/common/deploy-disabled-webarchive-pom.xml
+++ b/src/test/resources/unit/common/deploy-disabled-webarchive-pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>testing</groupId>
+	<artifactId>testing</artifactId>
+	<packaging>war</packaging>
+	<version>0.1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jboss.as.plugins</groupId>
+				<artifactId>jboss-as-maven-plugin</artifactId>
+				<executions>
+						<execution>
+							<goals>
+								<goal>deploy</goal>
+							</goals>
+						</execution>
+					</executions>
+				<configuration>
+					<id>testid</id>
+					<port>10099</port>
+					<targetDir>src/test/resources/unit/common/</targetDir>
+					<filename>test.war</filename>
+					<checkPackaging>false</checkPackaging>
+					<deployEnabled>false</deployEnabled>
+				</configuration>
+
+			</plugin>
+		</plugins>
+	</build>
+
+</project>


### PR DESCRIPTION
Allow the deployment of disabled WARs by using the 'add' functionality
of JBoss AS in place of 'deploy'.

If 'force' is true, the deployed content will have the same state as an
existing deployment, if any. That is, if the existing content is already
enabled, the 'add' goal will also enable the replacement content. If the
existing content is disabled, the 'add' goal will leave the replacement
content disabled.
