### PR TITLE
Undeploy in domain mode only undeploys a single deployment

### DIFF
--- a/src/main/java/org/jboss/as/plugin/deployment/domain/DomainDeployment.java
+++ b/src/main/java/org/jboss/as/plugin/deployment/domain/DomainDeployment.java
@@ -166,8 +166,8 @@ public class DomainDeployment implements Deployment {
 
         DeploymentActionsCompleteBuilder completeBuilder = null;
         for (String deploymentName : deploymentNames) {
-
-            completeBuilder = builder.undeploy(deploymentName).andRemoveUndeployed();
+            DeploymentPlanBuilder actualBuilder = (completeBuilder == null ? builder : completeBuilder);
+            completeBuilder = actualBuilder.undeploy(deploymentName).andRemoveUndeployed();
 
             if (matchPatternStrategy == MatchPatternStrategy.FIRST) {
                 break;


### PR DESCRIPTION
When using goal 'undeploy' for domain mode and a match-pattern that matches multiple deployments, only a single matching deployment is undeployed despite the match strategy being 'All'.
