### PR TITLE
backporting wildfly/wildfly-maven-plugin@95bfb7b with minor adaptations

### DIFF
--- a/src/main/java/org/jboss/as/plugin/server/DomainServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/DomainServer.java
@@ -161,7 +161,7 @@ final class DomainServer extends Server {
         cmd.add("-jar");
         cmd.add(modulesJar.getAbsolutePath());
         cmd.add("-mp");
-        cmd.add(serverInfo.getModulesDir().getAbsolutePath());
+        cmd.add(serverInfo.getModulesDir());
         cmd.add("org.jboss.as.process-controller");
         cmd.add("-jboss-home");
         cmd.add(jbossHome.getAbsolutePath());

--- a/src/main/java/org/jboss/as/plugin/server/ModulesPath.java
+++ b/src/main/java/org/jboss/as/plugin/server/ModulesPath.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.plugin.server;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Represents a module path element.
+ * <p/>
+ * Guarded by {@code this}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ModulesPath {
+
+    /**
+     * Defines a list of paths to be used for the modules path.
+     */
+    @Parameter(alias = "paths")
+    private File[] paths;
+
+    private File modulePath;
+
+    /**
+     * Returns the path or paths as a string delimited by the {@link File#pathSeparatorChar} if more than one path was
+     * defined.
+     *
+     * @return the modules directory path
+     */
+    public synchronized String get() {
+        if (paths == null && modulePath == null) {
+            return null;
+        }
+        if (paths == null) {
+            return modulePath.getAbsolutePath();
+        }
+        final StringBuilder result = new StringBuilder();
+        if (modulePath != null) {
+            result.append(modulePath.getAbsolutePath()).append(File.pathSeparatorChar);
+        }
+        for (int i = 0; i < paths.length; i++) {
+            result.append(paths[i].getAbsolutePath());
+            if (i + 1 < paths.length) {
+                result.append(File.pathSeparatorChar);
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Returns a list of invalid module paths. If no paths are invalid an empty list is returned.
+     *
+     * @return a list of invalid module paths or an empty list
+     */
+    public synchronized List<String> validate() {
+        if (paths == null && modulePath == null) {
+            return Collections.emptyList();
+        }
+        final Collection<File> files = new ArrayList<File>();
+        if (modulePath != null) {
+            files.add(modulePath);
+        }
+        if (paths != null) {
+            Collections.addAll(files, paths);
+        }
+        final List<String> result = new ArrayList<String>();
+        for (File file : files) {
+            if (!file.exists() || !file.isDirectory()) {
+                result.add(file.getAbsolutePath());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Sets the modules path. Used for Maven to allow a single path to be set.
+     *
+     * @param modulePath the module path to set
+     */
+    public synchronized void set(final File modulePath) {
+        this.modulePath = modulePath;
+    }
+}

--- a/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
+++ b/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
@@ -35,7 +35,7 @@ import org.jboss.as.plugin.common.Files;
 class ServerInfo {
     private final ConnectionInfo connectionInfo;
     private final File jbossHome;
-    private final File modulesDir;
+    private final String modulesDir;
     private final File bundlesDir;
     private final String[] jvmArgs;
     private final String javaHome;
@@ -47,7 +47,7 @@ class ServerInfo {
         this.connectionInfo = connectionInfo;
         this.javaHome = javaHome;
         this.jbossHome = jbossHome;
-        this.modulesDir = (modulesDir == null ? Files.createFile(jbossHome, "modules") : new File(modulesDir));
+        this.modulesDir = (modulesDir == null ? Files.createPath(jbossHome.getAbsolutePath(), "modules") : modulesDir);
         this.bundlesDir = (bundlesDir == null ? Files.createFile(jbossHome, "bundles") : new File(bundlesDir));
         this.jvmArgs = jvmArgs;
         this.serverConfig = serverConfig;
@@ -92,11 +92,11 @@ class ServerInfo {
     }
 
     /**
-     * The directory for all the modules.
+     * The directory or directories for all the modules.
      *
      * @return the modules directory
      */
-    public File getModulesDir() {
+    public String getModulesDir() {
         return modulesDir;
     }
 

--- a/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
@@ -124,12 +124,12 @@ final class StandaloneServer extends Server {
         cmd.add("-Djboss.home.dir=" + jbossHome);
         cmd.add("-Dorg.jboss.boot.log.file=" + jbossHome + "/standalone/log/boot.log");
         cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
-        cmd.add("-Djboss.modules.dir=" + serverInfo.getModulesDir().getAbsolutePath());
+//        cmd.add("-Djboss.modules.dir=" + serverInfo.getModulesDir());
         cmd.add("-Djboss.bundles.dir=" + serverInfo.getBundlesDir().getAbsolutePath());
         cmd.add("-jar");
         cmd.add(modulesJar.getAbsolutePath());
         cmd.add("-mp");
-        cmd.add(serverInfo.getModulesDir().getAbsolutePath());
+        cmd.add(serverInfo.getModulesDir());
         cmd.add("-jaxpmodule");
         cmd.add("javax.xml.jaxp-provider");
         cmd.add("org.jboss.as.standalone");

--- a/src/main/java/org/jboss/as/plugin/server/Start.java
+++ b/src/main/java/org/jboss/as/plugin/server/Start.java
@@ -24,6 +24,7 @@ package org.jboss.as.plugin.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -111,10 +112,11 @@ public class Start extends AbstractServerConnection {
     private String version;
 
     /**
-     * The modules path to use.
+     * The modules path or paths to use. A single path can be used or multiple paths by enclosing them in a paths
+     * element.
      */
     @Parameter(alias = "modules-path", property = PropertyNames.MODULES_PATH)
-    private String modulesPath;
+    private ModulesPath modulesPath;
 
     /**
      * The bundles path to use.
@@ -168,10 +170,11 @@ public class Start extends AbstractServerConnection {
         } else {
             javaHome = this.javaHome;
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
-        if (!serverInfo.getModulesDir().isDirectory()) {
-            throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", modulesPath));
+        final List<String> invalidPaths = modulesPath.validate();
+        if (!invalidPaths.isEmpty()) {
+            throw new MojoExecutionException("Invalid module path(s). " + invalidPaths);
         }
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
         // Print some server information
         log.info(String.format("JAVA_HOME=%s", javaHome));
         log.info(String.format("JBOSS_HOME=%s%n", jbossHome));

--- a/src/site/apt/examples/run-example.apt.vm
+++ b/src/site/apt/examples/run-example.apt.vm
@@ -1,0 +1,71 @@
+ ------
+ Run Example
+ ------
+ James R. Perkins
+ ------
+ 2014-02-13
+ ------
+
+Run Examples
+
+  The run goal allows you to run a local instance of ${appServerName}.
+
+* Run Example
+
+  The example below shows how to run a server with multiple module paths:
+
+----------
+<project>
+    ...
+    <build>
+        ...
+        <plugins>
+            ...
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <modules-path>
+                        <paths>
+                            <path>/opt/${appServerName}/modules</path>
+                            <path>/opt/my-modules</path>
+                        </paths>
+                    </modules-path>
+                </configuration>
+            </plugin>
+            ...
+        </plugins>
+        ...
+    </build>
+...
+</project>
+----------
+
+* Run with different port
+
+   The example below shows how to run a server with the management port running a different port.
+
+----------
+<project>
+    ...
+    <build>
+        ...
+        <plugins>
+            ...
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <jboss-home>/opt/${appServerName}</jboss-home>
+                    <modules-path>/opt/${appServerName}/modules</modules-path>
+                    <port>9999</port>
+                </configuration>
+            </plugin>
+            ...
+        </plugins>
+        ...
+    </build>
+...
+</project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -43,6 +43,7 @@
             <item name="Deploy Application Example" href="examples/deployment-example.html"/>
             <item name="Complex Example" href="examples/complex-example.html"/>
             <item name="Execute Commands Example" href="examples/execute-commands-example.html"/>
+            <item name="Run Example" href="examples/run-example.html"/>
         </menu>
 
         <menu name="Project Documentation">


### PR DESCRIPTION
Some changes of the original fix to cope for the fact that jboss-as is in java6 and not in java7
Plus commenting out the setting of the `-Djboss.modules.dir` since it is marked as deprecated in `org.jboss.as.server.ServerEnvironment`

Tested with JBoss EAP 6.2.0.GA (AS 7.3.0.Final-redhat-14)
