### PR TITLE
add a serverArgs configuration option

### DIFF
--- a/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
+++ b/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
@@ -83,4 +83,6 @@ public interface PropertyNames {
 
     String PROPERTIES_FILE = "jboss-as.propertiesFile";
 
+    String SERVER_ARGS = "jboss-as.serverArgs";
+
 }

--- a/src/main/java/org/jboss/as/plugin/server/DomainServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/DomainServer.java
@@ -173,6 +173,9 @@ final class DomainServer extends Server {
         cmd.add("--");
         cmd.add("-default-jvm");
         cmd.add(javaExec);
+        if (serverInfo.getServerArgs() != null) {
+            Collections.addAll(cmd, serverInfo.getServerArgs());
+        }
         return cmd;
     }
 

--- a/src/main/java/org/jboss/as/plugin/server/Run.java
+++ b/src/main/java/org/jboss/as/plugin/server/Run.java
@@ -145,6 +145,12 @@ public class Run extends Deploy {
     private String propertiesFile;
 
     /**
+     * A space delimited list of server arguments.
+     */
+    @Parameter(alias = "server-args", property = PropertyNames.SERVER_ARGS)
+    private String serverArgs;
+
+    /**
      * The timeout value to use when starting the server.
      */
     @Parameter(alias = "startup-timeout", defaultValue = Defaults.TIMEOUT, property = PropertyNames.STARTUP_TIMEOUT)
@@ -165,8 +171,6 @@ public class Run extends Deploy {
         if (!jbossHome.isDirectory()) {
             throw new MojoExecutionException(String.format("JBOSS_HOME '%s' is not a valid directory.", jbossHome));
         }
-        // JVM arguments should be space delimited
-        final String[] jvmArgs = (this.jvmArgs == null ? null : this.jvmArgs.split("\\s+"));
         final String javaHome;
         if (this.javaHome == null) {
             javaHome = SecurityActions.getEnvironmentVariable("JAVA_HOME");
@@ -177,7 +181,7 @@ public class Run extends Deploy {
         if (!invalidPaths.isEmpty()) {
             throw new MojoExecutionException("Invalid module path(s). " + invalidPaths);
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, splitBySpaces(jvmArgs), serverConfig, propertiesFile, splitBySpaces(serverArgs), startupTimeout);
 
         // Print some server information
         log.info(String.format("JAVA_HOME=%s", javaHome));
@@ -215,6 +219,10 @@ public class Run extends Deploy {
             throw new MojoExecutionException("The server failed to start", e);
         }
 
+    }
+
+    private String[] splitBySpaces(String args) {
+        return args == null ? null : args.split("\\s+");
     }
 
     private File extractIfRequired(final File buildDir) throws MojoFailureException, MojoExecutionException {

--- a/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
+++ b/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
@@ -41,9 +41,10 @@ class ServerInfo {
     private final String javaHome;
     private final String serverConfig;
     private final String propertiesFile;
+    private final String[] serverArgs;
     private final long startupTimeout;
 
-    private ServerInfo(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
+    private ServerInfo(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final String[] serverArgs, final long startupTimeout) {
         this.connectionInfo = connectionInfo;
         this.javaHome = javaHome;
         this.jbossHome = jbossHome;
@@ -52,6 +53,7 @@ class ServerInfo {
         this.jvmArgs = jvmArgs;
         this.serverConfig = serverConfig;
         this.propertiesFile = propertiesFile;
+        this.serverArgs = serverArgs;
         this.startupTimeout = startupTimeout;
     }
 
@@ -65,12 +67,13 @@ class ServerInfo {
      * @param bundlesDir     the bundles directory
      * @param jvmArgs        the JVM arguments
      * @param serverConfig   the path to the servers configuration file
+     * @param serverArgs     the arguments to pass to the main module
      * @param startupTimeout the startup timeout
      *
-     * @return the server configuration information
+     *  @return the server configuration information
      */
-    public static ServerInfo of(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
-        return new ServerInfo(connectionInfo, javaHome, jbossHome, modulesDir, bundlesDir, jvmArgs, serverConfig, propertiesFile, startupTimeout);
+    public static ServerInfo of(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final String[] serverArgs, final long startupTimeout) {
+        return new ServerInfo(connectionInfo, javaHome, jbossHome, modulesDir, bundlesDir, jvmArgs, serverConfig, propertiesFile, serverArgs, startupTimeout);
     }
 
     /**
@@ -143,6 +146,15 @@ class ServerInfo {
      */
     public String getPropertiesFile() {
         return propertiesFile;
+    }
+
+    /**
+     * The optional server arguments.
+     *
+     * @return the server arguments or {@code null} if there are none
+     */
+    public String[] getServerArgs() {
+        return serverArgs;
     }
 
     /**

--- a/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
@@ -141,6 +141,9 @@ final class StandaloneServer extends Server {
             cmd.add("-P");
             cmd.add(serverInfo.getPropertiesFile());
         }
+        if (serverInfo.getServerArgs() != null) {
+            Collections.addAll(cmd, serverInfo.getServerArgs());
+        }
         return cmd;
     }
 

--- a/src/main/java/org/jboss/as/plugin/server/Start.java
+++ b/src/main/java/org/jboss/as/plugin/server/Start.java
@@ -149,6 +149,12 @@ public class Start extends AbstractServerConnection {
     private String propertiesFile;
 
     /**
+     * A space delimited list of server arguments.
+     */
+    @Parameter(alias = "server-args", property = PropertyNames.SERVER_ARGS)
+    private String serverArgs;
+
+    /**
      * The timeout value to use when starting the server.
      */
     @Parameter(alias = "startup-timeout", defaultValue = Defaults.TIMEOUT, property = PropertyNames.STARTUP_TIMEOUT)
@@ -162,8 +168,6 @@ public class Start extends AbstractServerConnection {
         if (!jbossHome.isDirectory()) {
             throw new MojoExecutionException(String.format("JBOSS_HOME '%s' is not a valid directory.", jbossHome));
         }
-        // JVM arguments should be space delimited
-        final String[] jvmArgs = (this.jvmArgs == null ? null : this.jvmArgs.split("\\s+"));
         final String javaHome;
         if (this.javaHome == null) {
             javaHome = SecurityActions.getEnvironmentVariable("JAVA_HOME");
@@ -174,7 +178,7 @@ public class Start extends AbstractServerConnection {
         if (!invalidPaths.isEmpty()) {
             throw new MojoExecutionException("Invalid module path(s). " + invalidPaths);
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, splitBySpaces(jvmArgs), serverConfig, propertiesFile, splitBySpaces(serverArgs), startupTimeout);
         // Print some server information
         log.info(String.format("JAVA_HOME=%s", javaHome));
         log.info(String.format("JBOSS_HOME=%s%n", jbossHome));
@@ -191,6 +195,10 @@ public class Start extends AbstractServerConnection {
             throw new MojoExecutionException("The server failed to start", e);
         }
 
+    }
+
+    private String[] splitBySpaces(String args) {
+        return args == null ? null : args.split("\\s+");
     }
 
     private File extractIfRequired(final File buildDir) throws MojoFailureException, MojoExecutionException {


### PR DESCRIPTION
This works similarly to jvmArgs, except that the arguments are passed to the Main class run by jboss-modules instead of being passed to the JVM.

This implements https://issues.jboss.org/browse/JBASMP-72.
