### PR TITLE
Support new jbossBase property

### DIFF
--- a/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
+++ b/src/main/java/org/jboss/as/plugin/common/PropertyNames.java
@@ -83,4 +83,6 @@ public interface PropertyNames {
 
     String PROPERTIES_FILE = "jboss-as.propertiesFile";
 
+    String JBOSS_BASE = "jboss-as.base";
+
 }

--- a/src/main/java/org/jboss/as/plugin/server/DomainServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/DomainServer.java
@@ -135,6 +135,7 @@ final class DomainServer extends Server {
     @Override
     protected List<String> createLaunchCommand() {
         final File jbossHome = serverInfo.getJbossHome();
+        final File jbossBase = serverInfo.getJbossBase();
         final String javaHome = serverInfo.getJavaHome();
         final File modulesJar = new File(Files.createPath(jbossHome.getAbsolutePath(), "jboss-modules.jar"));
         if (!modulesJar.exists())
@@ -152,8 +153,12 @@ final class DomainServer extends Server {
         }
 
         cmd.add("-Djboss.home.dir=" + jbossHome);
-        cmd.add("-Dorg.jboss.boot.log.file=" + jbossHome + "/domain/log/process-controller.log");
-        cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
+        if (jbossBase != null) {
+            throw new IllegalStateException("Not supported : " + jbossBase);
+        } else {
+            cmd.add("-Dorg.jboss.boot.log.file=" + jbossHome + "/domain/log/process-controller.log");
+            cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
+        }
         cmd.add("-Djboss.bundles.dir=" + serverInfo.getBundlesDir().getAbsolutePath());
         // TODO (jrp) if this goes into production, these need to be used
         // cmd.add("-Djboss.domain.default.config=" + config.getDomainConfig());

--- a/src/main/java/org/jboss/as/plugin/server/Run.java
+++ b/src/main/java/org/jboss/as/plugin/server/Run.java
@@ -69,6 +69,12 @@ public class Run extends Deploy {
     private String jbossHome;
 
     /**
+     * The JBoss Application Server's base directory. May be null.
+     */
+    @Parameter(alias = "jboss-base", property = PropertyNames.JBOSS_BASE)
+    private String jbossBase;
+
+    /**
      * A string of the form groupId:artifactId:version[:packaging][:classifier]. Any missing portion of the artifact
      * will be replaced with the it's appropriate default property value
      */
@@ -165,6 +171,10 @@ public class Run extends Deploy {
         if (!jbossHome.isDirectory()) {
             throw new MojoExecutionException(String.format("JBOSS_HOME '%s' is not a valid directory.", jbossHome));
         }
+        final File jbossBase = new File(this.jbossBase);
+        if (!jbossBase.isDirectory()) {
+            throw new MojoExecutionException(String.format("JBOSS_BASE '%s' is not a valid directory.", jbossBase));
+        }
         // JVM arguments should be space delimited
         final String[] jvmArgs = (this.jvmArgs == null ? null : this.jvmArgs.split("\\s+"));
         final String javaHome;
@@ -177,11 +187,12 @@ public class Run extends Deploy {
         if (!invalidPaths.isEmpty()) {
             throw new MojoExecutionException("Invalid module path(s). " + invalidPaths);
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, jbossBase, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
 
         // Print some server information
         log.info(String.format("JAVA_HOME=%s", javaHome));
         log.info(String.format("JBOSS_HOME=%s%n", jbossHome));
+        log.info(String.format("JBOSS_BASE=%s%n", jbossBase));
         try {
             // Create the server
             final Server server = new StandaloneServer(serverInfo);

--- a/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
+++ b/src/main/java/org/jboss/as/plugin/server/ServerInfo.java
@@ -35,6 +35,7 @@ import org.jboss.as.plugin.common.Files;
 class ServerInfo {
     private final ConnectionInfo connectionInfo;
     private final File jbossHome;
+    private final File jbossBase;
     private final String modulesDir;
     private final File bundlesDir;
     private final String[] jvmArgs;
@@ -43,10 +44,11 @@ class ServerInfo {
     private final String propertiesFile;
     private final long startupTimeout;
 
-    private ServerInfo(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
+    private ServerInfo(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final File jbossBase, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
         this.connectionInfo = connectionInfo;
         this.javaHome = javaHome;
         this.jbossHome = jbossHome;
+        this.jbossBase = jbossBase;
         this.modulesDir = (modulesDir == null ? Files.createPath(jbossHome.getAbsolutePath(), "modules") : modulesDir);
         this.bundlesDir = (bundlesDir == null ? Files.createFile(jbossHome, "bundles") : new File(bundlesDir));
         this.jvmArgs = jvmArgs;
@@ -69,8 +71,8 @@ class ServerInfo {
      *
      * @return the server configuration information
      */
-    public static ServerInfo of(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
-        return new ServerInfo(connectionInfo, javaHome, jbossHome, modulesDir, bundlesDir, jvmArgs, serverConfig, propertiesFile, startupTimeout);
+    public static ServerInfo of(final ConnectionInfo connectionInfo, final String javaHome, final File jbossHome, final File jbossBase, final String modulesDir, final String bundlesDir, final String[] jvmArgs, final String serverConfig, final String propertiesFile, final long startupTimeout) {
+        return new ServerInfo(connectionInfo, javaHome, jbossHome, jbossBase, modulesDir, bundlesDir, jvmArgs, serverConfig, propertiesFile, startupTimeout);
     }
 
     /**
@@ -152,5 +154,9 @@ class ServerInfo {
      */
     public long getStartupTimeout() {
         return startupTimeout;
+    }
+
+    public File getJbossBase() {
+        return jbossBase;
     }
 }

--- a/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
+++ b/src/main/java/org/jboss/as/plugin/server/StandaloneServer.java
@@ -42,6 +42,7 @@ import org.jboss.dmr.ModelNode;
 final class StandaloneServer extends Server {
 
     private static final String CONFIG_PATH = "/standalone/configuration/";
+    private static final String LOG_PATH = "/standalone/log/";
     private static final String STARTING = "STARTING";
     private static final String STOPPING = "STOPPING";
 
@@ -105,6 +106,7 @@ final class StandaloneServer extends Server {
     @Override
     protected List<String> createLaunchCommand() {
         final File jbossHome = serverInfo.getJbossHome();
+        final File jbossBase = serverInfo.getJbossBase();
         final String javaHome = serverInfo.getJavaHome();
         final File modulesJar = new File(Files.createPath(jbossHome.getAbsolutePath(), "jboss-modules.jar"));
         if (!modulesJar.exists())
@@ -120,11 +122,17 @@ final class StandaloneServer extends Server {
         if (serverInfo.getJvmArgs() != null) {
             Collections.addAll(cmd, serverInfo.getJvmArgs());
         }
-
         cmd.add("-Djboss.home.dir=" + jbossHome);
-        cmd.add("-Dorg.jboss.boot.log.file=" + jbossHome + "/standalone/log/boot.log");
-        cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
-//        cmd.add("-Djboss.modules.dir=" + serverInfo.getModulesDir());
+
+        if (jbossBase == null) {
+            cmd.add("-Dorg.jboss.boot.log.file=" + jbossHome + LOG_PATH + "boot.log");
+            cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
+        } else {
+            cmd.add("-Djboss.server.base.dir=" + jbossBase + "/standalone");
+            cmd.add("-Dorg.jboss.boot.log.file=" + jbossBase + LOG_PATH + "boot.log");
+            cmd.add("-Dlogging.configuration=file:" + jbossBase + CONFIG_PATH + "logging.properties");
+        }
+        //        cmd.add("-Djboss.modules.dir=" + serverInfo.getModulesDir());
         cmd.add("-Djboss.bundles.dir=" + serverInfo.getBundlesDir().getAbsolutePath());
         cmd.add("-jar");
         cmd.add(modulesJar.getAbsolutePath());

--- a/src/main/java/org/jboss/as/plugin/server/Start.java
+++ b/src/main/java/org/jboss/as/plugin/server/Start.java
@@ -73,6 +73,12 @@ public class Start extends AbstractServerConnection {
     private String jbossHome;
 
     /**
+     * The JBoss Application Server's base directory. May be null.
+     */
+    @Parameter(alias = "jboss-base", property = PropertyNames.JBOSS_BASE)
+    private String jbossBase;
+
+    /**
      * A string of the form groupId:artifactId:version[:packaging][:classifier]. Any missing portion of the artifact
      * will be replaced with the it's appropriate default property value
      */
@@ -162,6 +168,10 @@ public class Start extends AbstractServerConnection {
         if (!jbossHome.isDirectory()) {
             throw new MojoExecutionException(String.format("JBOSS_HOME '%s' is not a valid directory.", jbossHome));
         }
+        final File jbossBase = new File(this.jbossBase);
+        if (!jbossBase.isDirectory()) {
+            throw new MojoExecutionException(String.format("JBOSS_BASE '%s' is not a valid directory.", jbossBase));
+        }
         // JVM arguments should be space delimited
         final String[] jvmArgs = (this.jvmArgs == null ? null : this.jvmArgs.split("\\s+"));
         final String javaHome;
@@ -174,10 +184,11 @@ public class Start extends AbstractServerConnection {
         if (!invalidPaths.isEmpty()) {
             throw new MojoExecutionException("Invalid module path(s). " + invalidPaths);
         }
-        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
+        final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, jbossBase, modulesPath.get(), bundlesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
         // Print some server information
         log.info(String.format("JAVA_HOME=%s", javaHome));
         log.info(String.format("JBOSS_HOME=%s%n", jbossHome));
+        log.info(String.format("JBOSS_BASE=%s%n", jbossBase));
         try {
             // Create the server
             final Server server = new StandaloneServer(serverInfo);


### PR DESCRIPTION
Adding support of 'jbossBase' property in jboss-as-maven-plugin configuration (beside 'jbossHome') enables to distinguish a JBoss "home" reference installation (pointed by 'jbossHome') from a working separated installation (pointed by 'jbossBase', assumed compliant with standard JBoss directory structure, typically localized inside project), keeping JBoss "home" immutable (no deployment, no logging, no changes in standalone.xml once deployment is done ...)

Such architecture could be obtained by setting property '-Djboss.server.base.dir=${jboss.base.dir}/standalone' in 'jvmArgs' but it faces to a logging issue : bootstrap logging starts on JBoss "home" side then continues on JBoss "base" side.

The current patch simplify the configuration (no need of '-Djboss.server.base.dir' property in 'jvmArgs ') and avoid the logging issue (see StandaloneServer.java refactoring)

Below an example of usage : 

```
        <plugin>
            <groupId>org.jboss.as.plugins</groupId>
            <artifactId>jboss-as-maven-plugin</artifactId>
            <version>${version.jboss-as-maven-plugin}</version>
            <configuration>
                <jbossHome>${jboss.home.dir}</jbossHome>
                <jbossBase>${jboss.base.dir}</jbossBase>
                <modules-path>
                    <paths>
                        <path>${jboss.base.dir}/modules</path>
                        <path>${jboss.home.dir}/modules</path>
                    </paths>
                </modules-path>
            </configuration>
        </plugin>               
```

Note : user already is able to manage its own set of modules which can complete native set of modules from JBoss "home" (thanks to a recent contribution from Juan-Manuel Cabrera to 7.6.Final). 
If 'modules-path' is not configured while 'jbossBase' is, a next step would be to force the default of 'modules-path' like above...
